### PR TITLE
Duplicate check init tokens

### DIFF
--- a/contracts/core/IndexSwap.sol
+++ b/contracts/core/IndexSwap.sol
@@ -162,6 +162,9 @@ contract IndexSwap is Initializable, ERC20Upgradeable, UUPSUpgradeable, OwnableU
     }
     uint256 totalWeight;
     for (uint256 i = 0; i < tokens.length; i++) {
+      if (_previousToken[tokens[i]] == true) {
+        revert ErrorLibrary.TokenAlreadyExist();
+      }
       address token = tokens[i];
       uint96 _denorm = denorms[i];
       IndexSwapLibrary._beforeInitCheck(IIndexSwap(address(this)), token, _denorm);
@@ -169,7 +172,9 @@ contract IndexSwap is Initializable, ERC20Upgradeable, UUPSUpgradeable, OwnableU
       _tokens.push(token);
 
       totalWeight = totalWeight + _denorm;
+      _previousToken[tokens[i]] = true;
     }
+    setFalse(tokens);
     _weightCheck(totalWeight);
     emit LOG_PUBLIC_SWAP_ENABLED(getTimeStamp());
   }

--- a/test/IndexFactory.test.ts
+++ b/test/IndexFactory.test.ts
@@ -741,6 +741,14 @@ describe.only("Tests for IndexFactory", () => {
           .withArgs("10000");
       });
 
+      it("initialize should revert for token duplicates", async () => {
+        const indexAddress = await indexFactory.getIndexList(0);
+        const index = indexSwap.attach(indexAddress);
+        await expect(
+          index.initToken([iaddress.btcAddress, iaddress.btcAddress], [5000, 5000]),
+        ).to.be.revertedWithCustomError(indexSwap, "TokenAlreadyExist");
+      });
+
       it("initialize should revert if tokens and denorms length is not equal", async () => {
         const indexAddress = await indexFactory.getIndexList(0);
         const index = indexSwap.attach(indexAddress);
@@ -2797,18 +2805,20 @@ describe.only("Tests for IndexFactory", () => {
         const config = await indexSwap.iAssetManagerConfig();
         const AssetManagerConfig = await ethers.getContractFactory("AssetManagerConfig");
         const assetManagerConfig = AssetManagerConfig.attach(config);
-        await expect(
-          assetManagerConfig.proposeNewEntryAndExitFee("20000", "200"),
-        ).to.be.revertedWithCustomError(assetManagerConfig, "InvalidFee");
+        await expect(assetManagerConfig.proposeNewEntryAndExitFee("20000", "200")).to.be.revertedWithCustomError(
+          assetManagerConfig,
+          "InvalidFee",
+        );
       });
 
       it("asset manager should not be able to propose wrong entry and exit fee(exit)", async () => {
         const config = await indexSwap.iAssetManagerConfig();
         const AssetManagerConfig = await ethers.getContractFactory("AssetManagerConfig");
         const assetManagerConfig = AssetManagerConfig.attach(config);
-        await expect(
-          assetManagerConfig.proposeNewEntryAndExitFee("200", "20000"),
-        ).to.be.revertedWithCustomError(assetManagerConfig, "InvalidFee");
+        await expect(assetManagerConfig.proposeNewEntryAndExitFee("200", "20000")).to.be.revertedWithCustomError(
+          assetManagerConfig,
+          "InvalidFee",
+        );
       });
 
       it("Asset manager should propose new entry and exit fee", async () => {


### PR DESCRIPTION
[ISSUE https://github.com/Velvet-Capital/protocol-v2/issues/1]: The same token can be added multiple times in IndexSwap.initToken() (low)
Description
The same token can be added multiple times in IndexSwap.initToken()'. If SUPER_ADMINaccidentally adds a token that has already been added, it will be pushed to_tokens. In this case, vaultBalanceis incorrectly calculated inIndexSwap.getTokenAndVaultBalance(). Since the vaultBalance` will be larger than the actual balance held, all calculations such as fee calculation and swap calculation will be incorrect. The swap may fail.
Attack Scenario
If SUPER_ADMIN accidentally adds a token once more that has already been added, the above problem will occur.
Attachments
If SUPER_ADMIN accidentally adds a token once more that has already been added, the above problem will occur.

==> if a token gets added twice into the portfolio the vault value calculated in IndexSwapLibrary.getTokenAndVaultBalance will be wrong.

Example Portfolio: BTC, BTC (portfolio value in USD: 50)

Iterating over both tokens:

BTC => value 50 USD
BTC => value 50 USD
=> 100 USD