### PR TITLE
Fixed Issue in enable primary bug

### DIFF
--- a/contracts/core/IndexSwap.sol
+++ b/contracts/core/IndexSwap.sol
@@ -162,17 +162,17 @@ contract IndexSwap is Initializable, ERC20Upgradeable, UUPSUpgradeable, OwnableU
     }
     uint256 totalWeight;
     for (uint256 i = 0; i < tokens.length; i++) {
-      if (_previousToken[tokens[i]] == true) {
+      address token = tokens[i];
+      if (_previousToken[token] == true) {
         revert ErrorLibrary.TokenAlreadyExist();
       }
-      address token = tokens[i];
       uint96 _denorm = denorms[i];
       IndexSwapLibrary._beforeInitCheck(IIndexSwap(address(this)), token, _denorm);
       _records[token] = Record({lastDenormUpdate: uint40(getTimeStamp()), denorm: _denorm, index: uint256(i)});
       _tokens.push(token);
 
       totalWeight = totalWeight + _denorm;
-      _previousToken[tokens[i]] = true;
+      _previousToken[token] = true;
     }
     setFalse(tokens);
     _weightCheck(totalWeight);

--- a/contracts/rebalance/OffChainRebalance.sol
+++ b/contracts/rebalance/OffChainRebalance.sol
@@ -436,8 +436,7 @@ contract OffChainRebalance is Initializable, ReentrancyGuardUpgradeable, UUPSUpg
     if (getRedeemed()) {
       revert ErrorLibrary.AlreadyOngoingOperation();
     }
-    address[] memory tokens = getTokens();
-    setPaused(true);
+    address[] memory tokens = setRebalanceDataAndPause();
     validatePrimaryAndHandler(tokens, offChainHandler);
     address[] memory sellTokens;
     updateRecord(tokens, newWeights);


### PR DESCRIPTION
Bug: enablePrimaryTokens function in OffChainRebalance.sol

Description: During testing we found a bug in the primary routine for updateWeight. When we have a fund with only primary tokens we call enablePrimaryTokens function if we want to update the weights. In this function we are only pausing the contracts but not storing the previous state of the contract. Thus, if the user wants to revert the first transaction, only WBNB token will be set in the token list of the fund only that will be displayed there. Since no previous state is available to be stored, only BNB will be pushed.

Impact: This will impact users and assetManagers. This will cause imbalance in portfolio, thus all investment and withdrawal will be affected since the token list will only consists WBNB token. The user’s funds will get locked in the vault unless the asset manager rebalances WBNB token into a previously existing token.