### PR TITLE
Aave Bug Fix

### DIFF
--- a/contracts/handler/Aave/AaveV3Handler.sol
+++ b/contracts/handler/Aave/AaveV3Handler.sol
@@ -160,9 +160,9 @@ contract AaveV3Handler is IHandler {
     if (t == address(0) || _tokenHolder == address(0)) {
       revert ErrorLibrary.InvalidAddress();
     }
+    IERC20Upgradeable aToken = IERC20Upgradeable(t);
     uint256[] memory tokenBalance = new uint256[](1);
-    IERC20Upgradeable underlyingToken = IERC20Upgradeable(getUnderlying(t)[0]);
-    tokenBalance[0] = underlyingToken.balanceOf(_tokenHolder);
+    tokenBalance[0] = aToken.balanceOf(_tokenHolder);
     return tokenBalance;
   }
 

--- a/test/Arbitrum/ArbitrumHandlers.test.ts
+++ b/test/Arbitrum/ArbitrumHandlers.test.ts
@@ -90,6 +90,7 @@ for (let protocolVariable = startLoopValue; protocolVariable <= endLoopValue; pr
     describe.only("Tests for Handler", () => {
       let accounts;
       let owner: SignerWithAddress;
+      let nonOwner : SignerWithAddress;
       let addrs: SignerWithAddress[];
       let approve_amount = ethers.constants.MaxUint256; //(2^256 - 1 )
       let token;
@@ -107,7 +108,7 @@ for (let protocolVariable = startLoopValue; protocolVariable <= endLoopValue; pr
       describe.only("Initial setup", () => {
         before(async () => {
           accounts = await ethers.getSigners();
-          [owner] = accounts;
+          [owner, nonOwner] = accounts;
           const no_of_inits = handlerJSON[protocolVariable - 1].no_of_inits;
           const HandlerName = handlerJSON[protocolVariable - 1].handlerName;
           const deployHandler = await ethers.getContractFactory(HandlerName);
@@ -125,7 +126,7 @@ for (let protocolVariable = startLoopValue; protocolVariable <= endLoopValue; pr
               handlerJSON[protocolVariable - 1].init_Array[1],
             );
             await handlerVariable.deployed();
-          } else if(no_of_inits == "3"){
+          } else if (no_of_inits == "3") {
             handlerVariable = await deployHandler.deploy(
               priceOracle.address,
               handlerJSON[protocolVariable - 1].init_Array[0],
@@ -133,8 +134,7 @@ for (let protocolVariable = startLoopValue; protocolVariable <= endLoopValue; pr
               handlerJSON[protocolVariable - 1].init_Array[2],
             );
             await handlerVariable.deployed();
-          }
-           else {
+          } else {
             handlerVariable = await deployHandler.deploy(priceOracle.address);
             await handlerVariable.deployed();
           }
@@ -521,7 +521,7 @@ for (let protocolVariable = startLoopValue; protocolVariable <= endLoopValue; pr
               _yieldAsset: dataArray[tokenVariable],
               _amount: handlerBalanceBefore,
               _lpSlippage: "600",
-              _to: owner.address,
+              _to: nonOwner.address,
               isWETH: checker,
             });
             redeem.wait();


### PR DESCRIPTION
The getUnderlyingBalance function, as currently implemented, is fetching the
balance of the underlying asset directly held by the _tokenHolder (which is the
vault in the context of the protocol). However, the intended functionality is to
return the equivalent underlying asset balance for a given amount of Aave V3
aTokens held by the vault.

Solution :-
uint256[] memory tokenBalance = new uint256;
tokenBalance[0] = aToken.balanceOf(_tokenHolder);

Because in aaveV3, the aTokens’ value is pegged to the value of the corresponding supplied asset at a 1:1 ratio and can be safely stored, transferred or traded. All yield collected by the aTokens' reserves are distributed to aToken holders directly by continuously increasing their wallet balance.