### PR TITLE
Compound Handler Fix

### DIFF
--- a/contracts/handler/Compound/CompoundV3Handler.sol
+++ b/contracts/handler/Compound/CompoundV3Handler.sol
@@ -95,9 +95,6 @@ contract CompoundV3Handler is IHandler {
 
     CometMainInterface cAsset = CometMainInterface(inputData._yieldAsset);
     uint256 assetBalance = IERC20Upgradeable(inputData._yieldAsset).balanceOf(address(this));
-    if (inputData._amount > assetBalance) {
-      revert ErrorLibrary.InsufficientBalance();
-    }
 
     address underlyingToken = getUnderlying(inputData._yieldAsset)[0];
     cAsset.withdraw(underlyingToken, assetBalance);

--- a/test/Arbitrum/CompoundHandler.test.ts
+++ b/test/Arbitrum/CompoundHandler.test.ts
@@ -451,7 +451,7 @@ describe.only("Tests for Compound", () => {
           _yieldAsset: addresses.cUSDCev3,
           _amount: balanceHandler,
           _lpSlippage: "800",
-          _to: owner.address,
+          _to: nonOwner.address,
           isWETH: false,
         });
         redeem.wait();

--- a/test/Arbitrum/MockSlippageControl.test.ts
+++ b/test/Arbitrum/MockSlippageControl.test.ts
@@ -19,7 +19,7 @@ describe.only("Tests for MixedIndex", () => {
 
   const forkChainId: any = process.env.FORK_CHAINID;
   const provider = ethers.provider;
-  const chainId: any = forkChainId ? forkChainId : 56;
+  const chainId: any = forkChainId ? forkChainId : 42161;
   const addresses = chainIdToAddresses[chainId];
 
   describe("Tests for MixedIndex ", () => {


### PR DESCRIPTION
Bug - The bug is in compound handler. We are able to invest in the compound protocol but are not able to withdraw from it. We found the compound protocol are rounding down the values when transferring cTokens. Thus, one of our checks which verifies the amount always reverts on us since the protocol rounds down the value.

Fix - Removing the amount check from the redeem function. Since the cTokens are sent to the handler and redeemed directly from the Compound protocol in the same transaction, eliminating this check won't pose a security risk.