### PR TITLE
Fixed Beefyhandler Redeem

### DIFF
--- a/contracts/handler/Beefy/BeefyBridgeHandler.sol
+++ b/contracts/handler/Beefy/BeefyBridgeHandler.sol
@@ -22,7 +22,6 @@ import {IERC20Upgradeable} from "@openzeppelin/contracts-upgradeable-4.3.2/token
 import {TransferHelper} from "@uniswap/lib/contracts/libraries/TransferHelper.sol";
 import {IERC20MetadataUpgradeable} from "@openzeppelin/contracts-upgradeable-4.3.2/token/ERC20/extensions/IERC20MetadataUpgradeable.sol";
 
-
 import {IHandler} from "../IHandler.sol";
 import {IVaultBeefy} from "./interfaces/IVaultBeefy.sol";
 import {ErrorLibrary} from "./../../library/ErrorLibrary.sol";
@@ -47,7 +46,8 @@ contract BeefyBridgeHandler is IHandler {
    */
 
   constructor(address _priceOracle, address _moo_eth, address _protocol_Handler) {
-    if (_priceOracle == address(0) || _moo_eth == address(0) || _protocol_Handler == address(0)) revert ErrorLibrary.InvalidAddress();
+    if (_priceOracle == address(0) || _moo_eth == address(0) || _protocol_Handler == address(0))
+      revert ErrorLibrary.InvalidAddress();
     _oracle = IPriceOracle(_priceOracle);
     MOO_ETH = _moo_eth;
     WETH = _oracle.WETH();
@@ -82,7 +82,7 @@ contract BeefyBridgeHandler is IHandler {
       if (msg.value != _amount[0]) {
         revert ErrorLibrary.MintAmountMustBeEqualToValue();
       }
-    }else{
+    } else {
       TransferHelper.safeTransfer(address(underlyingToken), Protocol_Handler, _amount[0]);
     }
 
@@ -115,12 +115,12 @@ contract BeefyBridgeHandler is IHandler {
       revert ErrorLibrary.NotEnoughBalanceInBeefyProtocol();
     }
     asset.withdraw(inputData._amount);
-    uint256 LPTokens = IERC20Upgradeable(underlyingLPToken).balanceOf(address(this));
-    TransferHelper.safeTransfer(underlyingLPToken, Protocol_Handler, LPTokens);
+    uint256 lPTokenAmount = IERC20Upgradeable(underlyingLPToken).balanceOf(address(this));
+    TransferHelper.safeTransfer(underlyingLPToken, Protocol_Handler, lPTokenAmount);
 
     IHandler(Protocol_Handler).redeem(
       FunctionParameters.RedeemData(
-        inputData._amount,
+        lPTokenAmount,
         inputData._lpSlippage,
         inputData._to,
         underlyingLPToken,
@@ -178,7 +178,9 @@ contract BeefyBridgeHandler is IHandler {
     IVaultBeefy asset = IVaultBeefy(_t);
 
     uint256[] memory underlyingBalance = new uint256[](1);
-    underlyingBalance[0] = (getTokenBalance(_tokenHolder, _t) * (asset.getPricePerFullShare()))/10 ** IERC20MetadataUpgradeable(_t).decimals();
+    underlyingBalance[0] =
+      (getTokenBalance(_tokenHolder, _t) * (asset.getPricePerFullShare())) /
+      10 ** IERC20MetadataUpgradeable(_t).decimals();
     return underlyingBalance;
   }
 
@@ -196,7 +198,11 @@ contract BeefyBridgeHandler is IHandler {
 
     IVaultBeefy token = IVaultBeefy(t);
     address underlyingLPToken = address(token.want());
-    uint underlyingBalance = IProtocolMetadata(Protocol_Handler).getUnderlyingAmount(_tokenHolder,lpBalance[0],underlyingLPToken);
+    uint underlyingBalance = IProtocolMetadata(Protocol_Handler).getUnderlyingAmount(
+      _tokenHolder,
+      lpBalance[0],
+      underlyingLPToken
+    );
 
     uint balanceUSD = _oracle.getPriceTokenUSD18Decimals(underlyingToken[0], underlyingBalance);
     return balanceUSD;

--- a/contracts/handler/Beefy/BeefyLPHandler.sol
+++ b/contracts/handler/Beefy/BeefyLPHandler.sol
@@ -107,7 +107,6 @@ contract BeefyLPHandler is IHandler, UniswapV2LPHandler {
         user
       );
     }
-
     uint256 lpTokensAmount = IERC20Upgradeable(underlyingLpToken).balanceOf(address(this));
     TransferHelper.safeApprove(address(underlyingLpToken), mooLpAsset, lpTokensAmount);
     IVaultBeefy(mooLpAsset).deposit(lpTokensAmount);
@@ -132,12 +131,12 @@ contract BeefyLPHandler is IHandler, UniswapV2LPHandler {
       revert ErrorLibrary.NotEnoughBalanceInBeefy();
     }
     asset.withdraw(inputData._amount);
-    uint256 LPTokens = IERC20Upgradeable(underlyingLpToken).balanceOf(address(this));
-    TransferHelper.safeTransfer(underlyingLpToken, lpHandlerAddress, LPTokens);
+    uint256 lPTokenAmount = IERC20Upgradeable(underlyingLpToken).balanceOf(address(this));
+    TransferHelper.safeTransfer(underlyingLpToken, lpHandlerAddress, lPTokenAmount);
 
     IHandler(lpHandlerAddress).redeem(
       FunctionParameters.RedeemData(
-        inputData._amount,
+        lPTokenAmount,
         inputData._lpSlippage,
         inputData._to,
         underlyingLpToken,
@@ -191,7 +190,8 @@ contract BeefyLPHandler is IHandler, UniswapV2LPHandler {
     IVaultBeefy asset = IVaultBeefy(t);
 
     address underlyingLpToken = address(IStrategy(address(asset.strategy())).want());
-    uint256 underlyingBalance = (getTokenBalance(_tokenHolder, t) * (asset.getPricePerFullShare()))/10 ** IERC20MetadataUpgradeable(t).decimals();
+    uint256 underlyingBalance = (getTokenBalance(_tokenHolder, t) * (asset.getPricePerFullShare())) /
+      10 ** IERC20MetadataUpgradeable(t).decimals();
     return _calculatePriceForBalance(underlyingLpToken, address(_oracle), underlyingBalance);
   }
 

--- a/test/Arbitrum/BeefyHandler.test.ts
+++ b/test/Arbitrum/BeefyHandler.test.ts
@@ -475,6 +475,8 @@ describe.only("Tests for Beefy", () => {
         redeem.wait();
 
         const balanceAfter = await mooHopEthToken.balanceOf(owner.address);
+        const lpBalance = await ERC20.attach(addresses.HOP_ETH_LP).balanceOf(hopHandler.address);
+        expect(lpBalance).to.be.equal(0);
         expect(Number(balanceBefore)).to.be.greaterThan(Number(balanceAfter));
       });
 

--- a/test/Arbitrum/BeefyLPHandler.test.ts
+++ b/test/Arbitrum/BeefyLPHandler.test.ts
@@ -460,6 +460,8 @@ describe.only("Tests for BeefyLP", () => {
         redeem.wait();
 
         const balanceAfter = await mooLPToken.balanceOf(owner.address);
+        const lpBalance = await ERC20.attach(addresses.SushiSwap_WETH_USDC).balanceOf(sushiLpHandler.address);
+        expect(lpBalance).to.be.equal(0);
         expect(Number(balanceBefore)).to.be.greaterThan(Number(balanceAfter));
       });
 


### PR DESCRIPTION
BeefyBridge and BeefyLP Incident
Severity
This issue is marked as P2 (We have an immediate fix for this, but require auditor's approval before re-deploying).

Summary
An issue was found in the the BeefyBridgeHandler file where the amount transferred after redeeming is correct but the value to be redeemed in the next step is wrong.

![image](https://github.com/Velvet-Capital/protocol-v2-public/assets/57176420/35b11281-4e55-42f5-bf9e-b3c39ec15ad9)

Details
Here we take example of issue token: moo-hop-usdt-lp We first redeem the moo tokens to get hop tokens. Then the next step would be to transfer the redeemed moo token amount to hop handler to be redeemed for base asset. But here we are transfering the new hop-lp token amount but in the redeeming parameter we sending old-amount as input. Thus, balances were left in the handler.

In the above code: We send first inputData._amount. Using the input we redeem into hop-tokens ans value is stored in LPTokens. But to redeem hop-tokens we are still sending inputData._amount instead of LPTokens. But we are transferring the new calculated amount. Thus, balances are left in the hop handler.

Similar issue after going again through the contracts was found in BeefyLP Handler on both ARB(Contract: 0xB1CB5f490339C0752D665C4e7bc3e5F2797690F0) and BSC(contract: 0x5Dec110904701E1888ff740362231f735b4D0487) chain.

Immediate Action
We have taken immediate action by disabling affected token in the frontend to prevent more exposure to users. We have also recovered the stuck funds through scripts.

Fix
We can fix this by changing the variable to new redeemed amount and redeploy and renable the handler for the moo-hop tokens. beefybridgeHandler-fix

![image](https://github.com/Velvet-Capital/protocol-v2-public/assets/57176420/48ce2824-acd9-4ed9-9cd1-51c69e7d8e79)

Impact
This impacts user a lot since wrong values are getting redeemed and balances of user's are stuck in the handler contract.