### PR TITLE
Fixed BeefyLpHandler Redeem Function

### DIFF
--- a/contracts/handler/Beefy/BeefyLPHandler.sol
+++ b/contracts/handler/Beefy/BeefyLPHandler.sol
@@ -46,7 +46,7 @@ contract BeefyLPHandler is IHandler, UniswapV2LPHandler {
   event Redeem(address indexed user, address indexed token, uint256 amount, address indexed to, bool isWETH);
 
   constructor(address _lpHandlerAddress, address _priceOracle) {
-     if(_priceOracle == address(0) || _lpHandlerAddress == address(0)){
+    if (_priceOracle == address(0) || _lpHandlerAddress == address(0)) {
       revert ErrorLibrary.InvalidAddress();
     }
     lpHandlerAddress = _lpHandlerAddress;
@@ -128,12 +128,12 @@ contract BeefyLPHandler is IHandler, UniswapV2LPHandler {
       revert ErrorLibrary.NotEnoughBalanceInBeefy();
     }
     asset.withdraw(inputData._amount);
-    uint256 LPTokens = IERC20Upgradeable(underlyingLpToken).balanceOf(address(this));
-    TransferHelper.safeTransfer(underlyingLpToken, lpHandlerAddress, LPTokens);
+    uint256 lPTokenAmount = IERC20Upgradeable(underlyingLpToken).balanceOf(address(this));
+    TransferHelper.safeTransfer(underlyingLpToken, lpHandlerAddress, lPTokenAmount);
 
     IHandler(lpHandlerAddress).redeem(
       FunctionParameters.RedeemData(
-        inputData._amount,
+        lPTokenAmount,
         inputData._lpSlippage,
         inputData._to,
         underlyingLpToken,
@@ -187,7 +187,8 @@ contract BeefyLPHandler is IHandler, UniswapV2LPHandler {
     IVaultBeefy asset = IVaultBeefy(t);
 
     address underlyingLpToken = address(IStrategy(address(asset.strategy())).want());
-    uint256 underlyingBalance = (getTokenBalance(_tokenHolder, t) * (asset.getPricePerFullShare()))/10 ** IERC20MetadataUpgradeable(t).decimals();
+    uint256 underlyingBalance = (getTokenBalance(_tokenHolder, t) * (asset.getPricePerFullShare())) /
+      10 ** IERC20MetadataUpgradeable(t).decimals();
     return _calculatePriceForBalance(underlyingLpToken, address(_oracle), underlyingBalance);
   }
 


### PR DESCRIPTION
Severity
This issue is marked as P2 (We have an immediate fix for this, but require auditor's approval before re-deploying).

Summary
An issue was found in the the BeefyBridgeHandler file where the amount transferred after redeeming is correct but the value to be redeemed in the next step is wrong.

![image](https://github.com/Velvet-Capital/protocol-v2-public/assets/57176420/35b11281-4e55-42f5-bf9e-b3c39ec15ad9)

Details
Here we take example of issue token: moo-hop-usdt-lp We first redeem the moo tokens to get hop tokens. Then the next step would be to transfer the redeemed moo token amount to hop handler to be redeemed for base asset. But here we are transfering the new hop-lp token amount but in the redeeming parameter we sending old-amount as input. Thus, balances were left in the handler.

In the above code: We send first inputData._amount. Using the input we redeem into hop-tokens ans value is stored in LPTokens. But to redeem hop-tokens we are still sending inputData._amount instead of LPTokens. But we are transferring the new calculated amount. Thus, balances are left in the hop handler.

Similar issue after going again through the contracts was found in BeefyLP Handler on both ARB(Contract: 0xB1CB5f490339C0752D665C4e7bc3e5F2797690F0) and BSC(contract: 0x5Dec110904701E1888ff740362231f735b4D0487) chain.

Immediate Action
We have taken immediate action by disabling affected token in the frontend to prevent more exposure to users. We have also recovered the stuck funds through scripts.

Fix
We can fix this by changing the variable to new redeemed amount and redeploy and renable the handler for the moo-hop tokens. beefybridgeHandler-fix

![image](https://github.com/Velvet-Capital/protocol-v2-public/assets/57176420/48ce2824-acd9-4ed9-9cd1-51c69e7d8e79)

Impact
This impacts user a lot since wrong values are getting redeemed and balances of user's are stuck in the handler contract.